### PR TITLE
fix: Check if model uses timestamp columns in QueryBuilder.php

### DIFF
--- a/src/Support/QueryBuilder.php
+++ b/src/Support/QueryBuilder.php
@@ -61,7 +61,7 @@ class QueryBuilder
             $this->query->vectorify();
         }
 
-        if (! empty($this->since) && method_exists($this->model, 'getUpdatedAtColumn')) {
+        if (! empty($this->since) && $this->model->usesTimestamps()) {
             $this->query->where(
                 column: $this->query->qualifyColumn($this->model->getUpdatedAtColumn()),
                 operator: '>=',


### PR DESCRIPTION
I got this error when running `php artisan vectorify:upsert`

`SQLSTATE[42S22]: Column not found: 1054 Unknown column 'tablename.updated_at' in 'WHERE' (Connection: mariadb, SQL: select ...`

I've removed `method_exists($this->model, 'getUpdatedAtColumn')` because all models have this method
I've added `$this->model->usesTimestamps()` that will fix this issue